### PR TITLE
Additional minor changes required for zcashd wallet import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,9 +94,9 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bc-components"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ad09f203e55dde31351a144ad497d36072dd0a571945f3a88992f2383f7f94"
+checksum = "350378302837b7b02d5f09eccfcaba9e33da63a4502ada497b7e48ad4c0ade73"
 dependencies = [
  "anyhow",
  "bc-crypto",
@@ -107,11 +119,12 @@ dependencies = [
 
 [[package]]
 name = "bc-crypto"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04934bfaaf6880d5fa71099ffc75435d45c7d066a9b42d6bccf2a4ca832947c1"
+checksum = "8647a24a5edf0ed9ea01f5258e7d092465c6f9b0508b32166c4dccbe1c291c9c"
 dependencies = [
  "anyhow",
+ "argon2",
  "bc-rand",
  "chacha20poly1305",
  "crc32fast",
@@ -130,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "bc-envelope"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a096ad7cc6a08a75df744d1f731d39863dcc91e12f6cf5beb1c441fd44a90b9"
+checksum = "38290e31247fd6a47d34568c7b05cb9bde4976405c1aa0b8f73f6349c130176f"
 dependencies = [
  "anyhow",
  "bc-components",
@@ -165,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "bc-shamir"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ea35338f9769920bc6bac820182a4b61108fa85151f63fd90983ae252adbe1"
+checksum = "3b6bdb46e87c24147d929cd78a93316ac118284825babeec47becd00395ee9eb"
 dependencies = [
  "bc-crypto",
  "bc-rand",
@@ -176,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "bc-tags"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b913ee5f2b0abd3fc0b4098aa88519ff20d6c30c21894eb47c4cc977bfa0b5"
+checksum = "fbfd44331570ae0d61d92f7d62408b215f6833da9c8d464eb09706a079363ce4"
 dependencies = [
  "dcbor",
  "paste",
@@ -186,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "bc-ur"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd117e4e52cd634f935220f4936e8283a1a2341dc8511ff7e913586f33687540"
+checksum = "c65e33cfacc82d2e6ef819ac08e73a429de526a4b019135fddbd2e14477ec2b2"
 dependencies = [
  "dcbor",
  "thiserror",
@@ -291,6 +304,15 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -601,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "dcbor"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd7515d6680292a81c11bd3371c7e553c0780371d932d6e6797e7e99ee38aff"
+checksum = "402f083d3c2daef249d4c06ef827c8b743ab88536f73dae52201f4de5abb0354"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1201,9 +1223,9 @@ dependencies = [
 
 [[package]]
 name = "known-values"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de45f9a353aea10da248d5e1b7270795f394eb95fb5f60d0daae71ae2ff426f8"
+checksum = "b7c3c5085ed0cb90e914af0906adca5fd87dd4af28ab6dc254edca97eee23a73"
 dependencies = [
  "bc-components",
  "dcbor",
@@ -1465,6 +1487,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -2116,9 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "sskr"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f412d410cd9e7b6eb62fcf7bc491970dfd25ea6dc06d1d6f087e927364a2dd86"
+checksum = "5ac11f99ef5cbbbc90a1eeeb4425d53af1e3ef9ff279102c009f643be2058e25"
 dependencies = [
  "bc-rand",
  "bc-shamir",
@@ -2769,7 +2802,7 @@ dependencies = [
 [[package]]
 name = "zewif"
 version = "0.1.0"
-source = "git+https://github.com/nuttycom/zewif.git?rev=9514ce42e0e8dd9a863359134bba621fd7065b45#9514ce42e0e8dd9a863359134bba621fd7065b45"
+source = "git+https://github.com/nuttycom/zewif.git?rev=8f005a6f5a189815dc08821f99cfe7e8af4e7f62#8f005a6f5a189815dc08821f99cfe7e8af4e7f62"
 dependencies = [
  "anyhow",
  "bc-components",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2769,7 +2769,7 @@ dependencies = [
 [[package]]
 name = "zewif"
 version = "0.1.0"
-source = "git+https://github.com/BlockchainCommons/zewif.git?rev=18592063cce454158e8110d0bd11be869fb67f60#18592063cce454158e8110d0bd11be869fb67f60"
+source = "git+https://github.com/nuttycom/zewif.git?rev=9514ce42e0e8dd9a863359134bba621fd7065b45#9514ce42e0e8dd9a863359134bba621fd7065b45"
 dependencies = [
  "anyhow",
  "bc-components",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,4 @@ default = []
 with-context = []
 
 [patch.crates-io]
-zewif = { git = "https://github.com/BlockchainCommons/zewif.git", rev = "18592063cce454158e8110d0bd11be869fb67f60" }
+zewif = { git = "https://github.com/nuttycom/zewif.git", rev = "9514ce42e0e8dd9a863359134bba621fd7065b45" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,4 @@ default = []
 with-context = []
 
 [patch.crates-io]
-zewif = { git = "https://github.com/nuttycom/zewif.git", rev = "9514ce42e0e8dd9a863359134bba621fd7065b45" }
+zewif = { git = "https://github.com/nuttycom/zewif.git", rev = "8f005a6f5a189815dc08821f99cfe7e8af4e7f62" }

--- a/src/bdb_dump.rs
+++ b/src/bdb_dump.rs
@@ -21,7 +21,7 @@ impl BDBDump {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .output()
-            .map_err(|e| anyhow!("Executing db_dump: {}", e))?;
+            .map_err(|e| anyhow!("Error executing db_dump against path {}: {}", filepath.to_string_lossy(), e))?;
 
         // Check if db_dump executed successfully
         if !output.status.success() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,5 @@ mod_use!(zcashd_parser);
 pub mod migrate;
 pub mod parser;
 pub mod zcashd_wallet;
-pub use zcashd_wallet::ZcashdWallet;
 pub use migrate::migrate_to_zewif;
+pub use zcashd_wallet::ZcashdWallet;

--- a/src/migrate/accounts.rs
+++ b/src/migrate/accounts.rs
@@ -88,7 +88,7 @@ pub fn convert_unified_accounts(
             if let Some(sapling_key) = find_sapling_key_for_ivk(wallet, viewing_key) {
                 // Convert to Zewif spending key format
                 shielded_address.set_spending_key(SaplingExtendedSpendingKey::new(
-                    sapling_key.key().to_bytes(),
+                    sapling_key.extsk().to_bytes(),
                 ));
             }
 

--- a/src/migrate/addresses.rs
+++ b/src/migrate/addresses.rs
@@ -94,7 +94,7 @@ pub fn convert_sapling_addresses(
         // Add spending key if available in sapling_keys
         if let Some(sapling_key) = find_sapling_key_for_ivk(wallet, viewing_key) {
             shielded_address.set_spending_key(SaplingExtendedSpendingKey::new(
-                sapling_key.key().to_bytes(),
+                sapling_key.extsk().to_bytes(),
             ));
         }
 

--- a/src/zcashd_dump.rs
+++ b/src/zcashd_dump.rs
@@ -108,9 +108,8 @@ impl ZcashdDump {
                 }
                 Err(e) if !strict => {
                     eprintln!(
-                        "Unable to parse key/value pair {} / {}: {}",
+                        "Unable to parse database key {}: {}",
                         key_data.encode_hex::<String>(),
-                        value_data.encode_hex::<String>(),
                         e
                     );
                 }

--- a/src/zcashd_parser.rs
+++ b/src/zcashd_parser.rs
@@ -582,7 +582,7 @@ impl<'a> ZcashdParser<'a> {
             .value_for_keyname("orchard_note_commitment_tree")
             .context("Getting 'orchard_note_commitment_tree' record")?;
         let orchard_note_commitment_tree = parse!(
-            buf = value.as_data(),
+            buf = &&value.as_data()[4..],
             OrchardNoteCommitmentTree,
             "orchard note commitment tree"
         )?;

--- a/src/zcashd_parser.rs
+++ b/src/zcashd_parser.rs
@@ -20,7 +20,7 @@ use crate::{
         orchard::OrchardNoteCommitmentTree,
         sapling::{SaplingKey, SaplingKeys, SaplingZPaymentAddress},
         sprout::{SproutKeys, SproutPaymentAddress, SproutSpendingKey},
-        transparent::{Key, KeyPoolEntry, Keys, PrivKey, PubKey, WalletKey, WalletKeys},
+        transparent::{KeyPair, KeyPoolEntry, Keys, PrivKey, PubKey, WalletKey, WalletKeys},
         u252,
     },
 };
@@ -263,8 +263,8 @@ impl<'a> ZcashdParser<'a> {
                 .value_for_key(&metakey)
                 .context("Getting metadata")?;
             let metadata = parse!(buf = metadata_binary, KeyMetadata, "metadata")?;
-            let keypair =
-                Key::new(pubkey.clone(), privkey.clone(), metadata).context("Creating keypair")?;
+            let keypair = KeyPair::new(pubkey.clone(), privkey.clone(), metadata)
+                .context("Creating keypair")?;
             keys_map.insert(pubkey, keypair);
 
             self.mark_key_parsed(&key);
@@ -297,7 +297,7 @@ impl<'a> ZcashdParser<'a> {
                 privkey.clone(),
                 time_created,
                 time_expires,
-                comment
+                comment,
             );
             keys_map.insert(pubkey, wallet_key);
 
@@ -335,8 +335,8 @@ impl<'a> ZcashdParser<'a> {
                 .value_for_key(&metakey)
                 .context("Getting sapzkeymeta metadata")?;
             let metadata = parse!(buf = metadata_binary, KeyMetadata, "sapzkeymeta metadata")?;
-            let keypair = SaplingKey::new(ivk, spending_key.clone(), metadata)
-                .context("Creating keypair")?;
+            let keypair =
+                SaplingKey::new(ivk, spending_key.clone(), metadata).context("Creating keypair")?;
             keys_map.insert(ivk, keypair);
 
             self.mark_key_parsed(&key);

--- a/src/zcashd_wallet.rs
+++ b/src/zcashd_wallet.rs
@@ -1,4 +1,4 @@
-use zewif::mod_use;
+use zewif::{LegacySeed, mod_use};
 
 mod_use!(address);
 mod_use!(block_locator);
@@ -46,6 +46,7 @@ pub struct ZcashdWallet {
     key_pool: HashMap<i64, KeyPoolEntry>,
     keys: Keys,
     min_version: ClientVersion,
+    legacy_hd_seed: Option<LegacySeed>,
     mnemonic_hd_chain: MnemonicHDChain,
     bip39_mnemonic: Bip39Mnemonic,
     network_info: NetworkInfo,
@@ -73,6 +74,7 @@ impl ZcashdWallet {
         key_pool: HashMap<i64, KeyPoolEntry>,
         keys: Keys,
         min_version: ClientVersion,
+        legacy_hd_seed: Option<LegacySeed>,
         mnemonic_hd_chain: MnemonicHDChain,
         bip39_mnemonic: Bip39Mnemonic,
         network_info: NetworkInfo,
@@ -97,6 +99,7 @@ impl ZcashdWallet {
             key_pool,
             keys,
             min_version,
+            legacy_hd_seed,
             mnemonic_hd_chain,
             bip39_mnemonic,
             network_info,
@@ -146,6 +149,10 @@ impl ZcashdWallet {
 
     pub fn min_version(&self) -> &ClientVersion {
         &self.min_version
+    }
+
+    pub fn legacy_hd_seed(&self) -> Option<&LegacySeed> {
+        self.legacy_hd_seed.as_ref()
     }
 
     pub fn mnemonic_hd_chain(&self) -> &MnemonicHDChain {

--- a/src/zcashd_wallet/key_metadata.rs
+++ b/src/zcashd_wallet/key_metadata.rs
@@ -65,8 +65,8 @@ impl Parse for KeyMetadata {
         Ok(Self {
             version,
             create_time,
-            hd_keypath,
-            seed_fp,
+            hd_keypath: hd_keypath.filter(|p| !p.trim().is_empty()),
+            seed_fp: seed_fp.filter(|fp| fp.as_bytes() != &[0u8; 32]),
         })
     }
 }

--- a/src/zcashd_wallet/sapling/sapling_key.rs
+++ b/src/zcashd_wallet/sapling/sapling_key.rs
@@ -8,25 +8,25 @@ use crate::zcashd_wallet::KeyMetadata;
 #[derive(Debug, Clone, PartialEq)]
 pub struct SaplingKey {
     ivk: SaplingIncomingViewingKey,
-    key: sapling::zip32::ExtendedSpendingKey,
+    extsk: sapling::zip32::ExtendedSpendingKey,
     metadata: KeyMetadata,
 }
 
 impl SaplingKey {
     pub fn new(
         ivk: SaplingIncomingViewingKey,
-        key: sapling::zip32::ExtendedSpendingKey,
+        extsk: sapling::zip32::ExtendedSpendingKey,
         metadata: KeyMetadata,
     ) -> Result<Self> {
-        Ok(Self { ivk, key, metadata })
+        Ok(Self { ivk, extsk, metadata })
     }
 
     pub fn ivk(&self) -> &SaplingIncomingViewingKey {
         &self.ivk
     }
 
-    pub fn key(&self) -> &sapling::zip32::ExtendedSpendingKey {
-        &self.key
+    pub fn extsk(&self) -> &sapling::zip32::ExtendedSpendingKey {
+        &self.extsk
     }
 
     pub fn metadata(&self) -> &KeyMetadata {

--- a/src/zcashd_wallet/transparent/key_pair.rs
+++ b/src/zcashd_wallet/transparent/key_pair.rs
@@ -8,13 +8,13 @@ use crate::zcashd_wallet::{
 };
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Key {
+pub struct KeyPair {
     pubkey: PubKey,
     privkey: PrivKey,
     metadata: KeyMetadata,
 }
 
-impl Key {
+impl KeyPair {
     pub fn pubkey(&self) -> &PubKey {
         &self.pubkey
     }
@@ -28,7 +28,7 @@ impl Key {
     }
 }
 
-impl Key {
+impl KeyPair {
     pub fn new(pubkey: PubKey, privkey: PrivKey, metadata: KeyMetadata) -> Result<Self> {
         let hash = hash256(Data::concat(&[&pubkey, &privkey]));
         if hash != privkey.hash() {

--- a/src/zcashd_wallet/transparent/keys.rs
+++ b/src/zcashd_wallet/transparent/keys.rs
@@ -1,17 +1,25 @@
 use std::collections::HashMap;
 
-use super::{Key, PubKey};
+use super::{KeyPair, PubKey};
 
 #[derive(Clone, PartialEq)]
-pub struct Keys(HashMap<PubKey, Key>);
+pub struct Keys(HashMap<PubKey, KeyPair>);
 
 impl Keys {
-    pub fn new(map: HashMap<PubKey, Key>) -> Self {
+    pub fn new(map: HashMap<PubKey, KeyPair>) -> Self {
         Self(map)
     }
 
-    pub fn keypairs(&self) -> impl Iterator<Item = &Key> {
+    pub fn keypairs(&self) -> impl Iterator<Item = &KeyPair> {
         self.0.values()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn keypair_for_pubkey(&self, pubkey: &PubKey) -> Option<&KeyPair> {
+        self.0.get(pubkey)
     }
 }
 
@@ -19,7 +27,7 @@ impl std::fmt::Debug for Keys {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let mut a = f.debug_list();
         for keypair in self.keypairs() {
-            a.entry(keypair);
+            a.entry(&keypair);
         }
         a.finish()
     }

--- a/src/zcashd_wallet/transparent/mod.rs
+++ b/src/zcashd_wallet/transparent/mod.rs
@@ -1,7 +1,7 @@
 use zewif::mod_use;
 
 mod_use!(key_id);
-mod_use!(key);
+mod_use!(key_pair);
 mod_use!(keys);
 mod_use!(priv_key);
 mod_use!(pub_key);

--- a/src/zcashd_wallet/transparent/priv_key.rs
+++ b/src/zcashd_wallet/transparent/priv_key.rs
@@ -19,6 +19,10 @@ impl PrivKey {
         &self.data
     }
 
+    pub fn as_slice(&self) -> &[u8] {
+        self.data.as_slice()
+    }
+
     pub fn hash(&self) -> u256 {
         self.hash
     }

--- a/src/zcashd_wallet/transparent/pub_key.rs
+++ b/src/zcashd_wallet/transparent/pub_key.rs
@@ -7,6 +7,19 @@ use crate::{parse, parser::prelude::*, zcashd_wallet::CompactSize};
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PubKey(Data);
 
+impl PubKey {
+    pub const PUBLIC_KEY_SIZE: usize = 65;
+    pub const COMPRESSED_PUBLIC_KEY_SIZE: usize = 33;
+
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+
+    pub fn is_compressed(&self) -> bool {
+        self.0.as_slice().len() == Self::COMPRESSED_PUBLIC_KEY_SIZE
+    }
+}
+
 impl std::fmt::Debug for PubKey {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "PubKey({:?})", &self.0)


### PR DESCRIPTION
This fixes a few minor parsing issues, and adds a non-strict parsing option to permit continue-on-failure semantics in the case that a zcashd wallet contains transaction data for transactions that do not parse according to any known consensus rules.